### PR TITLE
double quoting url

### DIFF
--- a/js/smoothproducts.js
+++ b/js/smoothproducts.js
@@ -1,5 +1,5 @@
 /*
- * Smoothproducts version 2.0.1
+ * Smoothproducts version 2.0.2
  * http://kthornbloom.com/smoothproducts.php
  *
  * Copyright 2013, Kevin Thornbloom
@@ -11,15 +11,12 @@
 	$.fn.extend({
 		smoothproducts: function() {
 
-
-			var slideTiming = 300
-
 			// Add some markup & set some CSS
 
 			$('.sp-loading').hide();
 			$('.sp-wrap').each(function() {
 				$(this).addClass('sp-touch');
-				thumbQty = $('a', this).length;
+				var thumbQty = $('a', this).length;
 
 				// If more than one image
 				if (thumbQty > 1) {
@@ -32,9 +29,8 @@
 					});
 					$('.sp-thumbs a:first', this).addClass('sp-current');
 					var firstLarge = $('.sp-thumbs a:first', this).attr('href'),
-						firstThumb = $('.sp-thumbs a:first', this).css('backgroundImage'),
-						firstThumb = firstThumb.replace('url(', '').replace(')', '');
-					$('.sp-large', this).append('<a href="' + firstLarge + '" class="sp-current-big"><img src="' + firstThumb + '"/></a>');
+						firstThumb = get_url_from_background($('.sp-thumbs a:first', this).css('backgroundImage'));
+					$('.sp-large', this).append('<a href="' + firstLarge + '" class="sp-current-big"><img src="' + firstThumb + '" alt="" /></a>');
 					$('.sp-wrap').css('display', 'inline-block');
 				// If only one image
 				} else {
@@ -43,7 +39,7 @@
 					$('.sp-wrap').css('display', 'inline-block');
 				}
 			});
-			
+
 
 			// Prevent clicking while things are happening
 			$(document.body).on('click', '.sp-thumbs', function(event) {
@@ -81,8 +77,7 @@
 				$(this).addClass('sp-current').parents('.sp-wrap').find('.sp-large a').remove();
 
 				var nextLarge = $(this).parent().find('.sp-current').attr('href'),
-					nextThumb = $(this).parent().find('.sp-current').css('backgroundImage'),
-					nextThumb = nextThumb.replace('url(', '').replace(')', '');
+					nextThumb = get_url_from_background($(this).parent().find('.sp-current').css('backgroundImage'));
 
 				$(this).parents('.sp-wrap').find('.sp-large').html('<a href="' + nextLarge + '" class="sp-current-big"><img src="' + nextThumb + '"/></a>');
 				$(this).parents('.sp-wrap').find('.sp-large').hide().fadeIn(250, function() {
@@ -125,7 +120,7 @@
 					currentThumb = ($(this).parents('.sp-wrap').find('.sp-thumbs .sp-current').index())+1;
 				$(this).parents('.sp-wrap').addClass('sp-selected');
 				$('body').append("<div class='sp-lightbox' data-currenteq='"+currentThumb+"'>" + currentImg + "</div>");
-				
+
 				if(thumbAmt > 1){
 					$('.sp-lightbox').append("<a href='#' id='sp-prev'></a><a href='#' id='sp-next'></a>");
 					if(currentThumb == 1) {
@@ -143,10 +138,10 @@
 				var currentImg = $(this).attr('href'),
 					thumbAmt = $(this).parents('.sp-wrap').find('.sp-thumbs a').length,
 					currentThumb = ($(this).parents('.sp-wrap').find('.sp-thumbs .sp-current').index())+1;
-				
+
 				$(this).parents('.sp-wrap').addClass('sp-selected');
-				$('body').append("<div class='sp-lightbox' data-currenteq='"+currentThumb+"'><img src='" + currentImg + "'/></div>");
-				
+				$('body').append('<div class="sp-lightbox" data-currenteq="'+currentThumb+'"><img src="' + currentImg + '"/></div>');
+
 				if(thumbAmt > 1){
 					$('.sp-lightbox').append("<a href='#' id='sp-prev'></a><a href='#' id='sp-next'></a>");
 					if(currentThumb == 1) {
@@ -168,9 +163,8 @@
 					if(currentEq >= totalItems) {
 					} else {
 						var nextEq = currentEq + 1,
-						newImg = $('.sp-selected .sp-thumbs').find('a:eq('+currentEq+')').attr('href');
-						newThumb = $('.sp-selected .sp-thumbs').find('a:eq('+currentEq+')').css('backgroundImage'),
-						newThumb = newThumb.replace('url(', '').replace(')', '');
+						newImg = $('.sp-selected .sp-thumbs').find('a:eq('+currentEq+')').attr('href'),
+						newThumb = get_url_from_background($('.sp-selected .sp-thumbs').find('a:eq('+currentEq+')').css('backgroundImage'));
 						if (currentEq == (totalItems - 1)) {
 							$('#sp-next').css('opacity','.1');
 						}
@@ -193,17 +187,15 @@
 
 				event.stopPropagation();
 				var currentEq = $('.sp-lightbox').data('currenteq'),
-					currentEq = currentEq - 1,
-					totalItems = $('.sp-selected .sp-thumbs a').length;
+					currentEq = currentEq - 1;
 					if(currentEq <= 0) {
 					} else {
 						if (currentEq == 1) {
 							$('#sp-prev').css('opacity','.1');
 						}
 						var nextEq = currentEq - 1,
-						newImg = $('.sp-selected .sp-thumbs').find('a:eq('+nextEq+')').attr('href');
-						newThumb = $('.sp-selected .sp-thumbs').find('a:eq('+nextEq+')').css('backgroundImage'),
-						newThumb = newThumb.replace('url(', '').replace(')', '');
+						newImg = $('.sp-selected .sp-thumbs').find('a:eq('+nextEq+')').attr('href'),
+						newThumb = get_url_from_background($('.sp-selected .sp-thumbs').find('a:eq('+nextEq+')').css('backgroundImage'));
 						$('#sp-next').css('opacity','1');
 						$('.sp-selected .sp-current').removeClass();
 						$('.sp-selected .sp-thumbs a:eq('+nextEq+')').addClass('sp-current');
@@ -219,7 +211,7 @@
 
 
 			// Close Lightbox
-			$(document.body).on('click', '.sp-lightbox', function(event) {
+			$(document.body).on('click', '.sp-lightbox', function() {
 				closeModal();
 			});
 
@@ -258,6 +250,10 @@
 				});
 
 			});
+
+			function get_url_from_background(bg){
+				return bg.match(/url\([\"\']{0,1}(.+)[\"\']{0,1}\)+/i)[1];
+			}
 		}
 	});
 })(jQuery);


### PR DESCRIPTION
With version 2.0.1 i was running into a problem where background image urls were being extracted from `url("path/image.jpg")`
the `url(` and `)` were removed leaving a double quoted string in the variable `"path/image.jpg"`
This was then being pasted to an image src producing `<img src=""path/image.jpg""/>`
Im seeing this in Windows based Firefox 36.0.1 and Internet Explorer 11.0 
Google Chrome 41.0.2272.89 m does not exhibit this issue