### PR TITLE
Add a link to the Rails plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ A lightweight & simple jQuery product viewer script by <a href="http://kthornblo
 	}
 ```
 
+##Plugins
+
+A Rails plugin providing the necessary files is [available here](https://github.com/calve/smoothproducts_rails).
 
 ##Licensing
 Free to use and modify personally or commercially. Not for resale. 


### PR DESCRIPTION
Hello

I just published a [Rails gem](https://rubygems.org/gems/smoothproducts_rails) providing facilities to benefit from your work in a Rails application.
Here are changes to notify you of it's existence, and to promote it.