### PR TITLE
add HTML5 cursor zoom for Edge

### DIFF
--- a/css/smoothproducts.css
+++ b/css/smoothproducts.css
@@ -96,6 +96,7 @@ html, body {
 	top: -50%;
 	cursor: -webkit-zoom-in;
 	cursor: -moz-zoom-in;
+	cursor: zoom-in;
 	display: none;
 }
 /* Lightbox */


### PR DESCRIPTION
Microsoft Edge browser only renders a zoom cursor with the HTML5 attribute. Also, it's a good idea to future-proof and break away from vendor prefixes.