### PR TITLE
Add default image loading with sp-default class

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,14 @@ A lightweight & simple jQuery product viewer script by <a href="http://kthornblo
 	    max-width: 300px;
 	}
 ```
+- You may add a class of "sp-default" to an image link. This will cause that image to be selected by default when the page loads, instead of the first image in the list.
+
+```
+<div class="sp-wrap">
+	<a href="images/1.jpg"><img src="images/1_tb.jpg" alt=""></a>
+	<a href="images/2.jpg" class="sp-default"><img src="images/2_tb.jpg" alt=""></a>
+</div>
+```
 
 ##Plugins
 

--- a/js/smoothproducts.js
+++ b/js/smoothproducts.js
@@ -20,17 +20,22 @@
 
 				// If more than one image
 				if (thumbQty > 1) {
+					var firstLarge,firstThumb,
+						defaultImage = $('a.sp-default', this)[0]?true:false;
 					$(this).append('<div class="sp-large"></div><div class="sp-thumbs sp-tb-active"></div>');
-					$('a', this).each(function() {
+					$('a', this).each(function(index) {
 						var thumb = $('img', this).attr('src'),
-							large = $(this).attr('href');
-						$(this).parents('.sp-wrap').find('.sp-thumbs').append('<a href="' + large + '" style="background-image:url(' + thumb + ')"></a>');
+							large = $(this).attr('href'),
+							classes = '';
+						//set default image
+						if((index === 0 && !defaultImage) || $(this).hasClass('sp-default')){
+							classes = ' class="sp-current"';
+							firstLarge = large;
+							firstThumb = $('img', this)[0].src;
+						}
+						$(this).parents('.sp-wrap').find('.sp-thumbs').append('<a href="' + large + '" style="background-image:url(' + thumb + ')"'+classes+'></a>');
 						$(this).remove();
 					});
-					$('.sp-thumbs a:first', this).addClass('sp-current');
-					var firstLarge = $('.sp-thumbs a:first', this).attr('href'),
-						firstThumb = get_url_from_background($('.sp-thumbs a:first', this).css('backgroundImage'));
-						//alert(firstThumb);
 					$('.sp-large', this).append('<a href="' + firstLarge + '" class="sp-current-big"><img src="' + firstThumb + '" alt="" /></a>');
 					$('.sp-wrap').css('display', 'inline-block');
 				// If only one image


### PR DESCRIPTION
This adds the option to include an "sp-default" class with an image link. This will cause that image to be loaded by default, instead of the first image in the list.

This does not include a new minified version of the js file, but as you do not specify the minify method you use, I will leave that up to you (honestly I would suggest dropping that from the project as most people use a task runner or their own method to minify now).